### PR TITLE
Allow dragging using the mousewheel or two-fingers trackpad scrolling.

### DIFF
--- a/myimgat/apps/wall/static/wall/js/init.js
+++ b/myimgat/apps/wall/static/wall/js/init.js
@@ -68,6 +68,7 @@
             var wall = new Wall("wall", {
                 draggable: true,
                 inertia: true,
+                mousewheel: true,
                 width: 128,
                 height: 128,
                 rangex: [-rangeSize, rangeSize],


### PR DESCRIPTION
It works very well on Webkit browsers, and not so well on Firefox.
The problem with Firefox is that sometimes it lags and keeps firing scrolling events even when we're already on a different scrolling direction.
The idea is to contribute this back to the-wall after some further tweaks to this code.
